### PR TITLE
tmux: unify size option and add orientation overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,15 +172,15 @@ $ tmux source-file ~/.tmux.conf
 If you want to open a playbook from a script you can use the `tome-open-playbook` command. It can be found where you installed the tmux plugin.
 
 ```
-Usage: tome-open-playbook [-s] [-l height]
+Usage: tome-open-playbook [-s] [-l size] [-H | -V]
 ```
 
 - `-s` will open a scratchpad
-- `-l` allows you to specify a height
-
+- `-l` allows you to specify a size in lines or percentage (e.g. `8` or `50%`)
+- `-H` forces a horizontal split for this run
+- `-V` forces a vertical split for this run
 
 ## Configuration
-
 
 ### Vim options
 
@@ -194,7 +194,6 @@ xmap <Leader>p <Plug>(TomePlaySelection)
 
 [See `help TomeConfig`](doc/tome.txt) in Vim to change them, and for more options.
 
-
 ### tmux options
 
 You can set any of these options by adding them to your `~/.tmux.conf` file:
@@ -203,14 +202,18 @@ You can set any of these options by adding them to your `~/.tmux.conf` file:
 set -g <option> "<value>"
 ```
 
-Where `<option>` and `<value>` correspond to one of the options specified below
+Where `<option>` and `<value>` correspond to one of the options specified below:
 
-| Option                 | Default         | Description |
-| :---                   | :---:           | :--- |
-| `@tome_key`            | `p`             | The key binding to open a Tome playbook. |
-| `@tome_scratch_key`    | `P`             | The key binding to open a Tome scratchpad. |
-| `@tome_height`         | `8`             | Height of the playbook vertial split. |
-| `@tome_editor`         | detect (n)vim   | Manually set your preferred editor. |
-| `@tome_playbook`       | `.playbook.sh`  | Name of the playbook to open. |
+| Option              |         Default        | Description                                                                                  |
+| :------------------ | :--------------------: | :------------------------------------------------------------------------------------------- |
+| `@tome_key`         |           `p`          | The key binding to open a Tome playbook.                                                     |
+| `@tome_scratch_key` |           `P`          | The key binding to open a Tome scratchpad.                                                   |
+| `@tome_size`        | depends on orientation | Size of the playbook split:<br>• `8` lines when vertical<br>• `50%` columns when horizontal. |
+| `@tome_height`      |     *(deprecated)*     | Legacy option kept for backward compatibility. Prefer `@tome_size`.                          |
+| `@tome_editor`      |      detect (n)vim     | Manually set your preferred editor.                                                          |
+| `@tome_playbook`    |     `.playbook.sh`     | Name of the playbook to open.                                                                |
 
+> **Note on orientation:** tmux names splits by the orientation of the dividing line, not the resulting panes.
+> - `vertical` split (`-v`) → panes stacked **top/bottom**
+> - `horizontal` split (`-h`) → panes side by side **left/right**
 

--- a/tome-open-playbook
+++ b/tome-open-playbook
@@ -1,42 +1,67 @@
 #!/bin/sh
 
 get_option() {
-	res=$(tmux show-option -gqv "$1")
-	echo "${res:-$2}"
+  res=$(tmux show-option -gqv "$1")
+  echo "${res:-$2}"
 }
 
-tome_height=$(get_option "@tome_height" 8)
+tome_orientation=$(get_option "@tome_orientation" vertical)
+tome_size=$(tmux show-option -gqv "@tome_size")
+if [ -z "$tome_size" ]; then
+  tome_size=$(get_option "@tome_height" "")
+fi
 tome_playbook=$(get_option "@tome_playbook" .playbook.sh)
 tome_editor=$(get_option "@tome_editor" -)
 scratchpad=0
+orient_override=""
 
-while getopts 'sl:h' opt; do
-	case "$opt" in
-	s) scratchpad=1 ;;
-	l) tome_height=$OPTARG ;;
-	*)
-		echo "Usage: $(basename "$0") [-s] [-l height]"
-		exit 1
-		;;
-	esac
+while getopts 'sl:HV' opt; do
+  case "$opt" in
+    s) scratchpad=1 ;;
+    l) tome_size=$OPTARG ;;
+    H) orient_override="horizontal" ;;
+    V) orient_override="vertical" ;;
+    *)
+      echo "Usage: $(basename "$0") [-s] [-l size] [-H | -V]"
+      exit 1
+      ;;
+  esac
 done
 
 if [ $tome_editor = '-' ]; then
-	# detect (n)vim
-	case "$EDITOR" in
-	*nvim*)
-		tome_editor="nvim"
-		;;
-	*)
-		tome_editor="vim"
-		;;
-	esac
+  # detect (n)vim
+  case "$EDITOR" in
+    *nvim*)
+      tome_editor="nvim"
+      ;;
+    *)
+      tome_editor="vim"
+      ;;
+  esac
 fi
 
-if [ $scratchpad = 1 ]; then
-	# open scratchpad
-	tmux split-window -c '#{pane_current_path}' -vb -l "$tome_height" "$tome_editor -c TomeScratchPad"
+if [ -n "$orient_override" ]; then
+  tome_orientation="$orient_override"
+fi
+
+if [ "$tome_orientation" = "horizontal" ]; then
+  orient="-h"
 else
-	# open tome playbook
-	tmux split-window -c '#{pane_current_path}' -vb -l "$tome_height" "$tome_editor -c TomePlayBook $tome_playbook"
+  orient="-v"
+fi
+
+if [ -z "$tome_size" ]; then
+  if [ "$tome_orientation" = "horizontal" ]; then
+    tome_size="50%"
+  else
+    tome_size="8"
+  fi
+fi
+
+if [ $scratchpad -eq 1 ]; then
+  # open scratchpad
+  tmux split-window -c '#{pane_current_path}' $orient -b -l "$tome_size" "$tome_editor -c TomeScratchPad"
+else
+  # open tome playbook
+  tmux split-window -c '#{pane_current_path}' $orient -b -l "$tome_size" "$tome_editor -c TomePlayBook $tome_playbook"
 fi


### PR DESCRIPTION
- introduce @tome_size option (unified split size)
- keep @tome_height for backward compatibility (deprecated)
- smart defaults for @tome_size based on orientation:
  • 8 lines when vertical
  • 50% when horizontal
- add `-H` and `-V` flags to override orientation per call
- keep `-l` for specifying size (lines or columns depending on orientation)
- updated README to document new options, defaults, and usage
