### PR TITLE
feat: add optional execution highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,32 @@ xmap <Leader>p <Plug>(TomePlaySelection)
 
 [See `help TomeConfig`](doc/tome.txt) in Vim to change them, and for more options.
 
+#### Execution highlighting (optional)
+
+You can optionally highlight what you execute (line/selection/paragraph) for a
+short time.
+
+Enable and configure in your vimrc:
+
+```
+" enable highlighting (default is 0/off)
+let g:tome_highlight_enabled = 1
+
+" how long to highlight in ms (default 500)
+let g:tome_highlight_duration = 500
+```
+
+Commands:
+
+```
+:TomeClearHighlight
+:TomeSetHighlightColor ctermbg=Yellow ctermfg=Black
+:TomeTestHighlight
+```
+
+The highlight links to `IncSearch` via the `TomeExecuted` group by default; you
+can customize colors with `:TomeSetHighlightColor ...`.
+
 ### tmux options
 
 You can set any of these options by adding them to your `~/.tmux.conf` file:

--- a/doc/tome.txt
+++ b/doc/tome.txt
@@ -114,4 +114,34 @@ let g:tome_vars = 0
 ```
 
 
+HIGHLIGHT EXECUTED TEXT                         *TomeHighlight*
+
+Tome can briefly highlight the text you execute (line/selection/paragraph),
+similar to vim-highlightedyank. This is disabled by default.
+
+Options:
+
+```
+" enable (default: 0)
+let g:tome_highlight_enabled = 1
+
+" duration in milliseconds (default: 500)
+let g:tome_highlight_duration = 500
+```
+
+Commands:
+
+```
+:TomeClearHighlight          " clear any active execution highlight
+:TomeSetHighlightColor {hl}  " set colors, e.g.: ctermbg=Yellow ctermfg=Black
+:TomeTestHighlight           " highlight current line to test your colors/setup
+```
+
+Notes:
+
+- By default the highlight links to |IncSearch| through the `TomeExecuted`
+  highlight group. You can customize it via `:TomeSetHighlightColor ...` or by
+  setting your own highlight group definition for `TomeExecuted`.
+
+
  vim:tw=78:ts=8:ft=help:norl:


### PR DESCRIPTION
- Add highlighting for executed text (line/selection/paragraph)
- Disabled by default (g:tome_highlight_enabled = 0)
- Configurable duration (default: 500ms)
- Commands: TomeClearHighlight, TomeSetHighlightColor, TomeTestHighlight
- Links to IncSearch highlight group by default
- Update documentation in doc/tome.txt and README.md